### PR TITLE
Reworked the errors in Endpoints.

### DIFF
--- a/src/endpoint_error.rs
+++ b/src/endpoint_error.rs
@@ -1,0 +1,39 @@
+use std::error::Error;
+use std::fmt;
+
+use diesel::result::Error as DieselError;
+
+pub type EndpointResult<T> = Result<T, EndpointError>;
+
+#[derive(Debug)]
+pub enum EndpointError {
+    Db(DieselError)
+}
+
+impl fmt::Display for EndpointError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            EndpointError::Db(ref err) => write!(f, "Db error {}", err),
+        }
+    }
+}
+
+impl Error for EndpointError {
+    fn description(&self) -> &str {
+        match *self {
+            EndpointError::Db(ref err) => err.description(),
+        }
+    }
+
+    fn cause(&self) -> Option<&Error> {
+        match *self {
+            EndpointError::Db(ref err) => Some(err),
+        }
+    }
+}
+
+impl From<DieselError> for EndpointError {
+    fn from(err: DieselError) -> EndpointError {
+        EndpointError::Db(err)
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,8 @@ pub mod config;
 pub mod env;
 pub mod db;
 
+mod endpoint_error;
+
 use env::Env;
 use config::DbConfig;
 use db::Db;


### PR DESCRIPTION
⚠️  This is way better than returning diesel errors.  ⚠️ 

Added new EndpointError type to represent errors raised in endpoint handlers.
Added new EnpointResult type to make endpoint handler signatures shorter.
Removed unused imports.
