### PR TITLE
Goyox86/more work on errors

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -1,15 +1,75 @@
+use std::fmt;
+use std::error;
 
 use diesel::pg::PgConnection;
 use r2d2::Config;
-use r2d2::Pool;
+use r2d2::{Pool, InitializationError};
 use r2d2_diesel::ConnectionManager;
 
 use config::DbConfig;
+
+use diesel::result::Error as DieselError;
+use r2d2::GetTimeout;
+
+#[derive(Debug)]
+pub enum DbError {
+    Db(DieselError),
+    PoolInitialization(InitializationError),
+    PoolTimeout(GetTimeout)
+}
+
+impl fmt::Display for DbError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            DbError::Db(_) => write!(f, "Db error"),
+            DbError::PoolInitialization(_) => write!(f, "Db pool could not be initialized"),
+            DbError::PoolTimeout(_) => write!(f, "Timeout while trying to access the Db Pool"),
+        }
+    }
+}
+
+impl error::Error for DbError {
+    fn description(&self) -> &str {
+        match *self {
+            DbError::Db(ref err) => err.description(),
+            DbError::PoolInitialization(ref err) => err.description(),
+            DbError::PoolTimeout(ref err) => err.description(),
+        }
+    }
+
+    fn cause(&self) -> Option<&error::Error> {
+        match *self {
+            DbError::Db(ref err) => Some(err),
+            DbError::PoolInitialization(ref err) => Some(err),
+            DbError::PoolTimeout(ref err) => Some(err),
+        }
+    }
+}
+
+impl From<DieselError> for DbError {
+    fn from(err: DieselError) -> DbError {
+        DbError::Db(err)
+    }
+}
+
+impl From<InitializationError> for DbError {
+    fn from(err: InitializationError) -> DbError {
+        DbError::PoolInitialization(err)
+    }
+}
+
+impl From<GetTimeout> for DbError {
+    fn from(err: GetTimeout) -> DbError {
+        DbError::PoolTimeout(err)
+    }
+}
 
 pub struct Db {
     pub pool: Option<Pool<ConnectionManager<PgConnection>>>,
     pub config: DbConfig,
 }
+
+type DbPool = Pool<ConnectionManager<PgConnection>>;
 
 impl Db {
     pub fn new(config: DbConfig) -> Db {
@@ -19,15 +79,16 @@ impl Db {
         }
     }
 
-    pub fn init(&mut self) {
+    pub fn init(&mut self) -> Result<(), DbError> {
         let db_url = self.config.url();
         let config = Config::default();
         let manager = ConnectionManager::<PgConnection>::new(db_url);
-        let pool = Pool::new(config, manager).expect("Failed to create DB connection pool.");
+        let pool = Pool::new(config, manager)?;
         self.pool = Some(pool);
+        Ok(())
     }
 
-    pub fn pool(&self) -> &Pool<ConnectionManager<PgConnection>> {
-        self.pool.as_ref().expect("Db Pool not available. Cannot continue. Exiting...")
+    pub fn pool(&self) -> &DbPool {
+        self.pool.as_ref().expect("Db Pool not available. Maybe call 'init()' first?")
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -2,7 +2,6 @@
 use diesel::pg::PgConnection;
 use r2d2::Config;
 use r2d2::Pool;
-use r2d2::PooledConnection;
 use r2d2_diesel::ConnectionManager;
 
 use config::DbConfig;

--- a/src/db.rs
+++ b/src/db.rs
@@ -31,9 +31,4 @@ impl Db {
     pub fn pool(&self) -> &Pool<ConnectionManager<PgConnection>> {
         self.pool.as_ref().unwrap()
     }
-
-    pub fn get_conn(&self) -> PooledConnection<ConnectionManager<PgConnection>> {
-        //TODO: Address this unwrap
-        self.pool().get().unwrap()
-    }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -28,6 +28,6 @@ impl Db {
     }
 
     pub fn pool(&self) -> &Pool<ConnectionManager<PgConnection>> {
-        self.pool.as_ref().unwrap()
+        self.pool.as_ref().expect("Db Pool not available. Cannot continue. Exiting...")
     }
 }

--- a/src/endpoint_error.rs
+++ b/src/endpoint_error.rs
@@ -2,18 +2,21 @@ use std::error::Error;
 use std::fmt;
 
 use diesel::result::Error as DieselError;
+use r2d2::GetTimeout;
 
 pub type EndpointResult<T> = Result<T, EndpointError>;
 
 #[derive(Debug)]
 pub enum EndpointError {
-    Db(DieselError)
+    Db(DieselError),
+    DbPool(GetTimeout)
 }
 
 impl fmt::Display for EndpointError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             EndpointError::Db(ref err) => write!(f, "Db error {}", err),
+            EndpointError::DbPool(ref err) => write!(f, "Db pool error {}", err),
         }
     }
 }
@@ -22,12 +25,14 @@ impl Error for EndpointError {
     fn description(&self) -> &str {
         match *self {
             EndpointError::Db(ref err) => err.description(),
+            EndpointError::DbPool(ref err) => err.description(),
         }
     }
 
     fn cause(&self) -> Option<&Error> {
         match *self {
             EndpointError::Db(ref err) => Some(err),
+            EndpointError::DbPool(ref err) => Some(err),
         }
     }
 }
@@ -35,5 +40,11 @@ impl Error for EndpointError {
 impl From<DieselError> for EndpointError {
     fn from(err: DieselError) -> EndpointError {
         EndpointError::Db(err)
+    }
+}
+
+impl From<GetTimeout> for EndpointError {
+    fn from(err: GetTimeout) -> EndpointError {
+        EndpointError::DbPool(err)
     }
 }

--- a/src/endpoint_error.rs
+++ b/src/endpoint_error.rs
@@ -2,21 +2,21 @@ use std::fmt;
 use std::error;
 
 use diesel::result::Error as DieselError;
-use r2d2::GetTimeout;
+use r2d2::{GetTimeout, InitializationError};
+
+use db::DbError;
 
 pub type EndpointResult<T> = Result<T, EndpointError>;
 
 #[derive(Debug)]
 pub enum EndpointError {
-    Db(DieselError),
-    DbPool(GetTimeout)
+    Db(DbError),
 }
 
 impl fmt::Display for EndpointError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             EndpointError::Db(ref err) => write!(f, "Db error {}", err),
-            EndpointError::DbPool(ref err) => write!(f, "Db pool error {}", err),
         }
     }
 }
@@ -25,26 +25,36 @@ impl error::Error for EndpointError {
     fn description(&self) -> &str {
         match *self {
             EndpointError::Db(ref err) => err.description(),
-            EndpointError::DbPool(ref err) => err.description(),
         }
     }
 
     fn cause(&self) -> Option<&error::Error> {
         match *self {
             EndpointError::Db(ref err) => Some(err),
-            EndpointError::DbPool(ref err) => Some(err),
         }
+    }
+}
+
+impl From<DbError> for EndpointError {
+    fn from(err: DbError) -> EndpointError {
+        EndpointError::Db(err)
     }
 }
 
 impl From<DieselError> for EndpointError {
     fn from(err: DieselError) -> EndpointError {
-        EndpointError::Db(err)
+        EndpointError::Db(DbError::from(err))
     }
 }
 
 impl From<GetTimeout> for EndpointError {
     fn from(err: GetTimeout) -> EndpointError {
-        EndpointError::DbPool(err)
+        EndpointError::Db(DbError::from(err))
+    }
+}
+
+impl From<InitializationError> for EndpointError {
+    fn from(err: InitializationError) -> EndpointError {
+        EndpointError::Db(DbError::from(err))
     }
 }

--- a/src/endpoint_error.rs
+++ b/src/endpoint_error.rs
@@ -1,5 +1,5 @@
-use std::error::Error;
 use std::fmt;
+use std::error;
 
 use diesel::result::Error as DieselError;
 use r2d2::GetTimeout;
@@ -21,7 +21,7 @@ impl fmt::Display for EndpointError {
     }
 }
 
-impl Error for EndpointError {
+impl error::Error for EndpointError {
     fn description(&self) -> &str {
         match *self {
             EndpointError::Db(ref err) => err.description(),
@@ -29,7 +29,7 @@ impl Error for EndpointError {
         }
     }
 
-    fn cause(&self) -> Option<&Error> {
+    fn cause(&self) -> Option<&error::Error> {
         match *self {
             EndpointError::Db(ref err) => Some(err),
             EndpointError::DbPool(ref err) => Some(err),

--- a/src/endpoints/api_v1/posts.rs
+++ b/src/endpoints/api_v1/posts.rs
@@ -15,7 +15,6 @@ use schema::posts::dsl::*;
 use schema::posts;
 use endpoint_error::{EndpointError, EndpointResult};
 
-//FIXME: don't return diesel::result::Error on all of these babies.
 #[get("/posts", format = "application/json")]
 fn api_v1_posts_index(db: State<Db>) -> EndpointResult<JSON<Value>> {
     let conn = &*db.pool().get()?;

--- a/src/endpoints/api_v1/posts.rs
+++ b/src/endpoints/api_v1/posts.rs
@@ -22,7 +22,7 @@ fn api_v1_posts_index(db: State<Db>) -> EndpointResult<JSON<Value>> {
     posts.filter(published.eq(false))
         .load::<Post>(conn)
         .map(|results| JSON(json!(results)))
-        .map_err(|err| EndpointError::Db(err))
+        .map_err(|err| EndpointError::from(err))
 }
 
 #[post("/posts", data = "<new_post>", format = "application/json")]
@@ -35,7 +35,7 @@ fn api_v1_posts_create(db: State<Db>,
         .into(posts::table)
         .get_result::<Post>(conn)
         .map(|post| JSON(post))
-        .map_err(|err| EndpointError::Db(err))
+        .map_err(|err| EndpointError::from(err))
 }
 
 #[get("/posts/<post_id>", format = "application/json")]
@@ -47,7 +47,7 @@ fn api_v1_posts_show(post_id: i32, db: State<Db>) -> EndpointResult<Response> {
         Err(err) => {
             match err {
                 DieselError::NotFound => Ok(not_found_json_response()),
-                _ => Err(EndpointError::Db(err)),
+                _ => Err(EndpointError::from(err)),
             }
         }
     }
@@ -69,7 +69,7 @@ fn api_v1_posts_update(db: State<Db>,
         Err(err) => {
             match err {
             DieselError::NotFound => Ok(not_found_json_response()),
-                _ => Err(EndpointError::Db(err)),
+                _ => Err(EndpointError::from(err)),
             }
         }
     }
@@ -86,7 +86,7 @@ fn api_v1_posts_destroy(post_id: i32, db: State<Db>) -> EndpointResult<Response>
         Err(err) => {
             match err {
                 DieselError::NotFound => Ok(not_found_json_response()),
-                _ => Err(EndpointError::Db(err)),
+                _ => Err(EndpointError::from(err)),
             }
         }
     }

--- a/src/endpoints/api_v1/posts.rs
+++ b/src/endpoints/api_v1/posts.rs
@@ -18,7 +18,7 @@ use endpoint_error::{EndpointError, EndpointResult};
 //FIXME: don't return diesel::result::Error on all of these babies.
 #[get("/posts", format = "application/json")]
 fn api_v1_posts_index(db: State<Db>) -> EndpointResult<JSON<Value>> {
-    let conn = &*db.pool().get().unwrap();
+    let conn = &*db.pool().get()?;
 
     posts.filter(published.eq(false))
         .load::<Post>(conn)
@@ -30,8 +30,7 @@ fn api_v1_posts_index(db: State<Db>) -> EndpointResult<JSON<Value>> {
 fn api_v1_posts_create(db: State<Db>,
                        new_post: JSON<NewPost>)
                        -> EndpointResult<JSON<Post>> {
-    //FIXME: Remove this unwrap
-    let conn = &*db.pool().get().unwrap();
+    let conn = &*db.pool().get()?;
 
     diesel::insert(&new_post.0)
         .into(posts::table)
@@ -42,8 +41,7 @@ fn api_v1_posts_create(db: State<Db>,
 
 #[get("/posts/<post_id>", format = "application/json")]
 fn api_v1_posts_show(post_id: i32, db: State<Db>) -> EndpointResult<Response> {
-    //FIXME: Remove this unwrap
-    let conn = &*db.pool().get().unwrap();
+    let conn = &*db.pool().get()?;
 
     match posts.find(post_id).first::<Post>(conn) {
         Ok(post) => Ok(ok_json_response(json!(post))),
@@ -61,8 +59,7 @@ fn api_v1_posts_update(db: State<Db>,
                        post_id: i32,
                        updated_post: JSON<NewPost>)
                        -> EndpointResult<Response> {
-    //FIXME: Remove this unwrap
-    let conn = &*db.pool().get().unwrap();
+    let conn = &*db.pool().get()?;
 
     let update_result = diesel::update(posts.find(post_id))
         .set((title.eq(&updated_post.title), body.eq(&updated_post.body)))
@@ -81,8 +78,7 @@ fn api_v1_posts_update(db: State<Db>,
 
 #[delete("/posts/<post_id>", format = "application/json")]
 fn api_v1_posts_destroy(post_id: i32, db: State<Db>) -> EndpointResult<Response> {
-    //FIXME: Remove this unwrap
-    let conn = &*db.pool().get().unwrap();
+    let conn = &*db.pool().get()?;
 
     match diesel::delete(posts.find(post_id)).get_result::<Post>(conn) {
         // TODO check why when I do Ok(json_response_with_status(Status::NoContent, json!({"status": "not_content"})))

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,6 @@ fn main() {
     let env = Env::from_str(env_str).unwrap();
     let db_config = DbConfig::load(&env).expect("Error loading DB configuration");
     let mut db = Db::new(db_config);
-    db.init();
 
     //TODO: Create the routes here when 'mount' gets fixed in rocket
     //let api_v1_routes = routes![api_v1::posts::api_v1_posts_index,
@@ -46,13 +45,16 @@ fn main() {
     //                            api_v1::posts::api_v1_posts_update,
     //                            api_v1::posts::api_v1_posts_destroy];
 
-    rocket::ignite()
-        .mount("/api/v1", routes![
-            api_v1::posts::api_v1_posts_index,
-            api_v1::posts::api_v1_posts_create,
-            api_v1::posts::api_v1_posts_show,
-            api_v1::posts::api_v1_posts_update,
-            api_v1::posts::api_v1_posts_destroy
-        ]).manage(db)
-        .launch()
+    match db.init() {
+        Ok(_) => {
+            rocket::ignite().mount("/api/v1", routes![
+                api_v1::posts::api_v1_posts_index,
+                api_v1::posts::api_v1_posts_create,
+                api_v1::posts::api_v1_posts_show,
+                api_v1::posts::api_v1_posts_update,
+                api_v1::posts::api_v1_posts_destroy
+            ]).manage(db).launch()
+        },
+        Err(err) => println!("Db initialization error: {}", err)
+    };
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,12 +18,12 @@ extern crate serde_derive;
 use std::env as std_env;
 use std::str::FromStr;
 
-pub mod schema;
-pub mod models;
-pub mod endpoints;
-pub mod config;
-pub mod env;
-pub mod db;
+mod schema;
+mod models;
+mod endpoints;
+mod config;
+mod env;
+mod db;
 
 mod endpoint_error;
 
@@ -39,6 +39,7 @@ fn main() {
     let mut db = Db::new(db_config);
     db.init();
 
+    //TODO: Create the routes here when 'mount' gets fixed in rocket
     //let api_v1_routes = routes![api_v1::posts::api_v1_posts_index,
     //                            api_v1::posts::api_v1_posts_create,
     //                           api_v1::posts::api_v1_posts_show,

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,14 +39,19 @@ fn main() {
     let mut db = Db::new(db_config);
     db.init();
 
-    let api_v1_routes = routes![api_v1::posts::api_v1_posts_index,
-                                api_v1::posts::api_v1_posts_create,
-                                api_v1::posts::api_v1_posts_show,
-                                api_v1::posts::api_v1_posts_update,
-                                api_v1::posts::api_v1_posts_destroy];
+    //let api_v1_routes = routes![api_v1::posts::api_v1_posts_index,
+    //                            api_v1::posts::api_v1_posts_create,
+    //                           api_v1::posts::api_v1_posts_show,
+    //                            api_v1::posts::api_v1_posts_update,
+    //                            api_v1::posts::api_v1_posts_destroy];
 
     rocket::ignite()
-        .mount("/api/v1", api_v1_routes)
-        .manage(db)
+        .mount("/api/v1", routes![
+            api_v1::posts::api_v1_posts_index,
+            api_v1::posts::api_v1_posts_create,
+            api_v1::posts::api_v1_posts_show,
+            api_v1::posts::api_v1_posts_update,
+            api_v1::posts::api_v1_posts_destroy
+        ]).manage(db)
         .launch()
 }


### PR DESCRIPTION
Reworked the errors types so:

- We have the `EndpointError` error as everything that can go wrong in our endpoints.
- And added a `DbError` type that represents everything that can be wrong when talking to the DB.
- Implemented `From` trait for those types so we can easily throw any error and that will get translated into a `EnpointError` variant.

I'm not completely happy with this because I will have to be implementing `From` for any possible error that might happen in a handler which can be literally anything. 

But this is a learning exercise so I'm gonna leave it there so I see how that code evolves or until I find a more Rustic way of doing it, right now I'm doing what I thought could be done with the info I have at the moment which is almost nothing \o/