### PR TITLE
Look ma! I've got Responder! AKA Implemented Responder for EndpointError <3 

### DIFF
--- a/src/endpoint_error.rs
+++ b/src/endpoint_error.rs
@@ -4,7 +4,11 @@ use std::error;
 use diesel::result::Error as DieselError;
 use r2d2::{GetTimeout, InitializationError};
 
+use rocket::response;
+use rocket::response::Responder;
+
 use db::DbError;
+use endpoints::helpers::*;
 
 pub type EndpointResult<T> = Result<T, EndpointError>;
 
@@ -56,5 +60,15 @@ impl From<GetTimeout> for EndpointError {
 impl From<InitializationError> for EndpointError {
     fn from(err: InitializationError) -> EndpointError {
         EndpointError::Db(DbError::from(err))
+    }
+}
+
+
+impl<'r> Responder<'r> for EndpointError {
+    fn respond(self) -> response::Result<'r> {
+        match self {
+            EndpointError::Db(DbError::Db(DieselError::NotFound)) => Ok(not_found_json_response()),
+            _ => Ok(ise_json_response())
+        }
     }
 }

--- a/src/endpoints/api_v1/users.rs
+++ b/src/endpoints/api_v1/users.rs
@@ -1,6 +1,5 @@
 use diesel::prelude::*;
 use diesel;
-use diesel::result::Error as DieselError;
 
 use rocket::{State, Response};
 use rocket::http::Status;
@@ -11,63 +10,50 @@ use models::User;
 use models::NewUser;
 use models::UpdatedUser;
 use schema::posts::dsl::*;
-use schema::posts;
 use schema::users::dsl::*;
 use schema::users;
 
-use endpoint_error::{EndpointError, EndpointResult};
+use endpoint_error::{EndpointResult};
 use endpoints::helpers::*;
 
 #[get("/users", format = "application/json")]
 fn api_v1_users_index(db: State<Db>) -> EndpointResult<JSON<Value>> {
     let conn = &*db.pool().get()?;
 
-    users.load::<User>(conn)
-        .map(|results| JSON(json!(results)))
-        .map_err(|err| EndpointError::from(err))
+    let results = users.load::<User>(conn)?;
+
+    Ok(JSON(json!(results)))
 }
 
 #[post("/users", data = "<new_user>", format = "application/json")]
 fn api_v1_users_create(db: State<Db>, new_user: JSON<NewUser>) -> EndpointResult<JSON<User>> {
     let conn = &*db.pool().get()?;
 
-    diesel::insert(&new_user.0)
+    let user = diesel::insert(&new_user.0)
         .into(users::table)
-        .get_result::<User>(conn)
-        .map(|user| JSON(user))
-        .map_err(|err| EndpointError::from(err))
+        .get_result::<User>(conn)?;
+
+    Ok(JSON(user))
 }
 
 #[get("/users/<id>", format = "application/json")]
 fn api_v1_users_show(id: i32, db: State<Db>) -> EndpointResult<Response> {
     let conn = &*db.pool().get()?;
 
-    users.find(id).first::<User>(conn)
-        .and_then(|user| Ok(ok_json_response(json!(user))))
-        .or_else(|err| {
-            match err {
-                DieselError::NotFound => Ok(not_found_json_response()),
-                _ => Err(EndpointError::from(err)),
-            }
-        })
+    let user = users.find(id).first::<User>(conn)?;
+
+    Ok(ok_json_response(json!(user)))
 }
 
-// FIXME: This should behave like a Rails update only update the fields passed in the payload.
 #[put("/users/<id>", data = "<updated_user>", format = "application/json")]
 fn api_v1_users_update(db: State<Db>, id: i32, updated_user: JSON<UpdatedUser>) -> EndpointResult<Response> {
     let conn = &*db.pool().get()?;
 
-    diesel::update(users.find(id))
+    let user = diesel::update(users.find(id))
         .set(&updated_user.0)
-        .get_result::<User>(conn)
-        .and_then(|user| Ok(ok_json_response(json!(user))))
-        .or_else(|err| {
-            match err {
-                DieselError::NotFound => Ok(not_found_json_response()),
-                _ => Err(EndpointError::from(err)),
-            }
-        })
+        .get_result::<User>(conn)?;
 
+    Ok(ok_json_response(json!(user)))
 }
 
 #[delete("/users/<id>", format = "application/json")]
@@ -75,13 +61,8 @@ fn api_v1_users_destroy(id: i32, db: State<Db>) -> EndpointResult<Response> {
     let conn = &*db.pool().get()?;
 
     diesel::delete(users.find(id))
-        .get_result::<User>(conn)
-        .and_then(|_| Ok(empty_response_with_status(Status::NoContent)))
-        .or_else(|err| {
-            match err {
-                DieselError::NotFound => Ok(not_found_json_response()),
-                _ => Err(EndpointError::from(err)),
-            }
-        })
+        .get_result::<User>(conn)?;
+
+    Ok(empty_response_with_status(Status::NoContent))
 }
 

--- a/src/endpoints/mod.rs
+++ b/src/endpoints/mod.rs
@@ -1,7 +1,7 @@
 
 pub mod api_v1;
 
-mod helpers {
+pub mod helpers {
     use rocket::http::Status;
     use rocket::Response;
     use rocket_contrib::{JSON, Value};
@@ -21,6 +21,11 @@ mod helpers {
 
     pub fn not_found_json_response<'r>() -> Response<'r> {
         json_response_with_status(Status::NotFound, json!({"status": "not_found"}))
+    }
+
+    pub fn ise_json_response<'r>() -> Response<'r> {
+        json_response_with_status(Status::InternalServerError,
+                                  json!({"status": "an internal error has occured"}))
     }
 
     pub fn ok_json_response<'r>(json: Value) -> Response<'r> {


### PR DESCRIPTION
Implemented Rockets 'Responder' for 'EnpointError' and as product the code across all the endpoints is significantly simpler, more idiomatic and more importantly is LESS code.

- Implemented 'Responder' trait for 'EndpointError'.
- Handling diesel not founds there.
- Implemented posts and users endpoints on top of '?'. (They look secsy now).
- Added new response helpers for internal server error and wired it in 'EndpointError's 'Responder' implementation.
- Misc.

\o/