### PR TITLE
There is no need to get the result of the 'delete' call.

### DIFF
--- a/src/endpoints/api_v1/posts.rs
+++ b/src/endpoints/api_v1/posts.rs
@@ -62,7 +62,7 @@ fn api_v1_posts_update(db: State<Db>, id: i32, updated_post: JSON<UpdatedPost>) 
 fn api_v1_posts_destroy(id: i32, db: State<Db>) -> EndpointResult<Response> {
     let conn = &*db.pool().get()?;
 
-    diesel::delete(posts.find(id)).get_result::<Post>(conn)?;
+    diesel::delete(posts.find(id)).execute(conn)?;
 
     Ok(empty_response_with_status(Status::NoContent))
 }

--- a/src/endpoints/api_v1/users.rs
+++ b/src/endpoints/api_v1/users.rs
@@ -60,8 +60,7 @@ fn api_v1_users_update(db: State<Db>, id: i32, updated_user: JSON<UpdatedUser>) 
 fn api_v1_users_destroy(id: i32, db: State<Db>) -> EndpointResult<Response> {
     let conn = &*db.pool().get()?;
 
-    diesel::delete(users.find(id))
-        .get_result::<User>(conn)?;
+    diesel::delete(users.find(id)).execute(conn)?;
 
     Ok(empty_response_with_status(Status::NoContent))
 }


### PR DESCRIPTION
Just a formality PR 😄 

We don't need to call 'get_result'.