### PR TITLE
First implementation of dumb pagination.

### DIFF
--- a/src/endpoints/api_v1/comments.rs
+++ b/src/endpoints/api_v1/comments.rs
@@ -18,13 +18,27 @@ use schema::users::dsl::*;
 
 use endpoint_error::EndpointResult;
 use endpoints::helpers::*;
+use endpoints::pagination::Pagination;
 
+
+//TODO: Put the common code to get the comments into a reusable function
 #[get("/comments", format = "application/json")]
 fn index(db: State<Db>) -> EndpointResult<JSON<Value>> {
     let conn = &*db.pool().get()?;
 
     // TODO add back the 'published' restriction
     let results = comments.load::<Comment>(conn)?;
+
+    Ok(JSON(json!(results)))
+}
+
+#[get("/comments?<pagination>", format = "application/json")]
+fn index_paginated(db: State<Db>, pagination: Pagination) -> EndpointResult<JSON<Value>> {
+    let conn = &*db.pool().get()?;
+
+    let results = comments.limit(pagination.per_page)
+        .offset(pagination.per_page * (pagination.page - 1))
+        .load::<Comment>(conn)?;
 
     Ok(JSON(json!(results)))
 }

--- a/src/endpoints/api_v1/posts.rs
+++ b/src/endpoints/api_v1/posts.rs
@@ -16,12 +16,27 @@ use schema::users::dsl::*;
 
 use endpoint_error::EndpointResult;
 use endpoints::helpers::*;
+use endpoints::pagination::Pagination;
 
+
+//TODO: Put the common code to get the posts into a reusable function
 #[get("/posts", format = "application/json")]
 fn index(db: State<Db>) -> EndpointResult<JSON<Value>> {
     let conn = &*db.pool().get()?;
 
     let results = posts.filter(published.eq(false))
+        .load::<Post>(conn)?;
+
+    Ok(JSON(json!(results)))
+}
+
+#[get("/posts?<pagination>", format = "application/json")]
+fn index_paginated(db: State<Db>, pagination: Pagination) -> EndpointResult<JSON<Value>> {
+    let conn = &*db.pool().get()?;
+
+    let results = posts.filter(published.eq(false))
+        .limit(pagination.per_page)
+        .offset(pagination.per_page * (pagination.page - 1))
         .load::<Post>(conn)?;
 
     Ok(JSON(json!(results)))

--- a/src/endpoints/api_v1/users.rs
+++ b/src/endpoints/api_v1/users.rs
@@ -15,12 +15,25 @@ use schema::users;
 
 use endpoint_error::EndpointResult;
 use endpoints::helpers::*;
+use endpoints::pagination::Pagination;
 
+//TODO: Put the common code to get the users into a reusable function
 #[get("/users", format = "application/json")]
 fn index(db: State<Db>) -> EndpointResult<JSON<Value>> {
     let conn = &*db.pool().get()?;
 
     let results = users.load::<User>(conn)?;
+
+    Ok(JSON(json!(results)))
+}
+
+#[get("/users?<pagination>", format = "application/json")]
+fn index_paginated(db: State<Db>, pagination: Pagination) -> EndpointResult<JSON<Value>> {
+    let conn = &*db.pool().get()?;
+
+    let results = users.limit(pagination.per_page)
+        .offset(pagination.per_page * (pagination.page - 1))
+        .load::<User>(conn)?;
 
     Ok(JSON(json!(results)))
 }

--- a/src/endpoints/mod.rs
+++ b/src/endpoints/mod.rs
@@ -1,5 +1,6 @@
 
 pub mod api_v1;
+pub mod pagination;
 
 pub mod helpers {
     use rocket::http::Status;

--- a/src/endpoints/pagination.rs
+++ b/src/endpoints/pagination.rs
@@ -1,0 +1,6 @@
+
+#[derive(FromForm)]
+pub struct Pagination {
+    pub per_page: i64,
+    pub page: i64
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(plugin)]
+#![feature(plugin, custom_derive)]
 #![plugin(rocket_codegen)]
 
 #[macro_use]
@@ -44,6 +44,7 @@ fn main() {
                 .mount("/api/v1",
                        routes![
                 api_v1::posts::index,
+                api_v1::posts::index_paginated,
                 api_v1::posts::create,
                 api_v1::posts::show,
                 api_v1::posts::update,
@@ -51,11 +52,13 @@ fn main() {
                 api_v1::posts::user_posts_index,
                 api_v1::posts::user_post_show,
                 api_v1::users::index,
+                api_v1::users::index_paginated,
                 api_v1::users::create,
                 api_v1::users::show,
                 api_v1::users::update,
                 api_v1::users::destroy,
                 api_v1::comments::index,
+                api_v1::comments::index_paginated,
                 api_v1::comments::create,
                 api_v1::comments::show,
                 api_v1::comments::update,


### PR DESCRIPTION
As I said very basic paginated versions of the 'index' endpoint actions.

- Added 'Pagination'struct and auto-derived 'FromForm'for it.
- Put 'Pagination into it's module.
- Added index_paginated actions on users, posts and comments endpoints. 

Left to be done:
- Abstract the reusable code of the index actions into a reusable entity.
- Make a function to pass the query and it will paginate it. 