### PR TITLE
More flexible pagination. (Default values)

### DIFF
--- a/src/endpoints/api_v1/comments.rs
+++ b/src/endpoints/api_v1/comments.rs
@@ -36,8 +36,11 @@ fn index(db: State<Db>) -> EndpointResult<JSON<Value>> {
 fn index_paginated(db: State<Db>, pagination: Pagination) -> EndpointResult<JSON<Value>> {
     let conn = &*db.pool().get()?;
 
-    let results = comments.limit(pagination.per_page)
-        .offset(pagination.per_page * (pagination.page - 1))
+    let page = pagination.get_page();
+    let per_page = pagination.get_per_page();
+
+    let results = comments.limit(per_page)
+        .offset(per_page * (page - 1))
         .load::<Comment>(conn)?;
 
     Ok(JSON(json!(results)))

--- a/src/endpoints/api_v1/posts.rs
+++ b/src/endpoints/api_v1/posts.rs
@@ -34,9 +34,12 @@ fn index(db: State<Db>) -> EndpointResult<JSON<Value>> {
 fn index_paginated(db: State<Db>, pagination: Pagination) -> EndpointResult<JSON<Value>> {
     let conn = &*db.pool().get()?;
 
+    let page = pagination.get_page();
+    let per_page = pagination.get_per_page();
+
     let results = posts.filter(published.eq(false))
-        .limit(pagination.per_page)
-        .offset(pagination.per_page * (pagination.page - 1))
+        .limit(per_page)
+        .offset(per_page * (page - 1))
         .load::<Post>(conn)?;
 
     Ok(JSON(json!(results)))

--- a/src/endpoints/api_v1/users.rs
+++ b/src/endpoints/api_v1/users.rs
@@ -31,8 +31,11 @@ fn index(db: State<Db>) -> EndpointResult<JSON<Value>> {
 fn index_paginated(db: State<Db>, pagination: Pagination) -> EndpointResult<JSON<Value>> {
     let conn = &*db.pool().get()?;
 
-    let results = users.limit(pagination.per_page)
-        .offset(pagination.per_page * (pagination.page - 1))
+    let page = pagination.get_page();
+    let per_page = pagination.get_per_page();
+
+    let results = users.limit(per_page)
+        .offset(per_page * (page - 1))
         .load::<User>(conn)?;
 
     Ok(JSON(json!(results)))

--- a/src/endpoints/pagination.rs
+++ b/src/endpoints/pagination.rs
@@ -1,6 +1,29 @@
+use std::default::Default;
+
+const DEFAULT_PER_PAGE: i64 = 10;
+const DEFAULT_PAGE: i64 = 1;
 
 #[derive(FromForm)]
 pub struct Pagination {
-    pub per_page: i64,
-    pub page: i64
+    per_page: Option<i64>,
+    page: Option<i64>
+}
+
+impl Default for Pagination {
+    fn default() -> Self {
+        Self {
+            per_page: Some(DEFAULT_PER_PAGE),
+            page: Some(DEFAULT_PAGE)
+        }
+    }
+}
+
+impl Pagination {
+    pub fn get_per_page(&self) -> i64 {
+        self.per_page.unwrap_or(DEFAULT_PER_PAGE)
+    }
+
+    pub fn get_page(&self) -> i64 {
+        self.page.unwrap_or(DEFAULT_PAGE)
+    }
 }


### PR DESCRIPTION
- Added default values for pagination so you can hit the paginated index
actions so page and per_page are optional and some sane defaults get
used if they are not provided.
- Implemented 'Default' for 'Pagination'.
- Added getters for page and per_page fields on 'Pagination' struct.

\o/!